### PR TITLE
change workflow syntax on README.md : HCL -> YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,42 +2,76 @@
 
 Automate publishing Go build artifacts for GitHub releases through GitHub Actions
 
-```hcl
-# .github/main.workflow
+```yaml
+# .github/workflows/release.yaml
 
-workflow "Build" {
-  on = "release"
-  resolves = [
-    "release darwin/amd64",
-    "release windows/amd64",
-    "release linux/amd64",
-  ]
-}
-
-action "release darwin/amd64" {
-  uses = "ngs/go-release.action@v1.0.1"
-  env = {
-    GOOS = "darwin"
-    GOARCH = "amd64"
-  }
-  secrets = ["GITHUB_TOKEN"]
-}
-
-action "release windows/amd64" {
-  uses = "ngs/go-release.action@v1.0.1"
-  env = {
-    GOOS = "windows"
-    GOARCH = "amd64"
-  }
-  secrets = ["GITHUB_TOKEN"]
-}
-
-action "release linux/amd64" {
-  uses = "ngs/go-release.action@v1.0.1"
-  env = {
-    GOOS = "linux"
-    GOARCH = "amd64"
-  }
-  secrets = ["GITHUB_TOKEN"]
-}
+on: release
+name: Build
+jobs:
+  release-linux-386:
+    name: release linux/386
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: "386"
+        GOOS: linux
+  release-linux-amd64:
+    name: release linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: amd64
+        GOOS: linux
+  release-darwin-386:
+    name: release darwin/386
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: "386"
+        GOOS: darwin
+  release-darwin-amd64:
+    name: release darwin/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: amd64
+        GOOS: darwin
+  release-windows-386:
+    name: release windows/386
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: "386"
+        GOOS: windows
+  release-windows-amd64:
+    name: release windows/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: amd64
+        GOOS: windows
 ```


### PR DESCRIPTION
> Support for the HCL syntax in GitHub Actions will be deprecated on September 30, 2019. To continue using workflows that you created with the HCL syntax, you'll need to migrate the workflow files to the new YAML syntax using the migration script.

ref. https://help.github.com/en/articles/migrating-github-actions-from-hcl-syntax-to-yaml-syntax