### PR TITLE
support custom target name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)
 UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
 RELEASE_NAME=$(echo $EVENT_DATA | jq -r .release.tag_name)
 PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
-NAME="${PROJECT_NAME}_${RELEASE_NAME}_${GOOS}_${GOARCH}"
+NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${GOOS}_${GOARCH}"
 
 EXT=''
 


### PR DESCRIPTION
We hope out there is not version info in file name of release. Because we can see the version in the release notes, and also our app can get the version by type `--version` option, so we add the wrap code.