### PR TITLE
go-release upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.14-alpine
 MAINTAINER Atsushi Nagase <a@ngs.io> (https://ngs.io)
 
 LABEL "com.github.actions.name"="Go Release Binary"
@@ -7,13 +7,13 @@ LABEL "com.github.actions.icon"="cpu"
 LABEL "com.github.actions.color"="orange"
 
 LABEL "name"="Automate publishing Go build artifacts for GitHub releases through GitHub Actions"
-LABEL "version"="1.0.1"
+LABEL "version"="1.0.2"
 LABEL "repository"="http://github.com/ngs/go-release.action"
 LABEL "homepage"="http://ngs.io/t/actions/"
 
 LABEL "maintainer"="Atsushi Nagase <a@ngs.io> (https://ngs.io)"
 
-RUN apk add --no-cache curl jq git build-base
+RUN apk add --no-cache curl jq git build-base bash zip
 
 ADD entrypoint.sh /entrypoint.sh
 ADD build.sh /build.sh

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Go Release Binary GitHub Action
 
-Automate publishing Go build artifacts for GitHub releases through GitHub Actions
+Automate publishing Go build artifacts for GitHub releases through GitHub Actions.
+
+Detects a build.sh in the go repo and will use that instead.  Expects a list of
+file artifacts in a single, space delimited line as output for packaging.
+
+Extra environment variables:
+* CMD_PATH
+  * Pass extra commands to go build
+* EXTRA_FILES
+  * Pass a list of extra files for packaging.
+    * Example: EXTRA_FILES: "README.md LICENSE"
 
 ```yaml
 # .github/workflows/release.yaml
 
 on: release
-name: Build
+name: Build Release
 jobs:
   release-linux-386:
     name: release linux/386
@@ -19,6 +29,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: "386"
         GOOS: linux
+        EXTRA_FILES: "LICENSE"
   release-linux-amd64:
     name: release linux/amd64
     runs-on: ubuntu-latest
@@ -30,8 +41,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: amd64
         GOOS: linux
-  release-darwin-386:
-    name: release darwin/386
+        EXTRA_FILES: "LICENSE"
+  release-linux-arm:
+    name: release linux/386
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -39,8 +51,21 @@ jobs:
       uses: ngs/go-release.action@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: "386"
-        GOOS: darwin
+        GOARCH: "arm"
+        GOOS: linux
+        EXTRA_FILES: "LICENSE"
+  release-linux-arm64:
+    name: release linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: compile and release
+      uses: ngs/go-release.action@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: arm64
+        GOOS: linux
+        EXTRA_FILES: "LICENSE"
   release-darwin-amd64:
     name: release darwin/amd64
     runs-on: ubuntu-latest
@@ -52,6 +77,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: amd64
         GOOS: darwin
+        EXTRA_FILES: "LICENSE"
   release-windows-386:
     name: release windows/386
     runs-on: ubuntu-latest
@@ -63,6 +89,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: "386"
         GOOS: windows
+        EXTRA_FILES: "LICENSE"
   release-windows-amd64:
     name: release windows/amd64
     runs-on: ubuntu-latest
@@ -74,4 +101,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: amd64
         GOOS: windows
+        EXTRA_FILES: "LICENSE"
 ```

--- a/build.sh
+++ b/build.sh
@@ -9,4 +9,18 @@ rmdir $PROJECT_ROOT
 ln -s $GITHUB_WORKSPACE $PROJECT_ROOT
 cd $PROJECT_ROOT
 go get -v ./...
-go build
+
+EXT=''
+
+if [ $GOOS == 'windows' ]; then
+EXT='.exe'
+fi
+
+if [ -x "./build.sh" ]; then
+  OUTPUT=`./build.sh "${CMD_PATH}"`
+else
+  go build "${CMD_PATH}"
+  OUTPUT="${PROJECT_NAME}${EXT}"
+fi
+
+echo ${OUTPUT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,15 +27,23 @@ FILE_LIST="${FILE_LIST} ${EXTRA_FILES}"
 
 FILE_LIST=`echo "${FILE_LIST}" | awk '{$1=$1};1'`
 
-tar cvfz tmp.tgz ${FILE_LIST}
-CHECKSUM=$(md5sum tmp.tgz | cut -d ' ' -f 1)
+
+if [ $GOOS == 'windows' ]; then
+ARCHIVE=tmp.zip
+zip -9r $ARCHIVE ${FILE_LIST}
+else
+ARCHIVE=tmp.tgz
+tar cvfz $ARCHIVE ${FILE_LIST}
+fi
+
+CHECKSUM=$(md5sum ${ARCHIVE} | cut -d ' ' -f 1)
 
 curl \
   -X POST \
-  --data-binary @tmp.tgz \
-  -H 'Content-Type: application/gzip' \
+  --data-binary @${ARCHIVE} \
+  -H 'Content-Type: application/octet-stream' \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  "${UPLOAD_URL}?name=${NAME}.tar.gz"
+  "${UPLOAD_URL}?name=${NAME}.${ARCHIVE/tmp./}"
 
 curl \
   -X POST \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,14 @@
 
 set -eux
 
-/build.sh
+if [ -z "${CMD_PATH+x}" ]; then
+  echo "::warning file=entrypoint.sh,line=6,col=1::CMD_PATH not set"
+  export CMD_PATH=""
+fi
+
+FILE_LIST=`/build.sh`
+
+#echo "::warning file=/build.sh,line=1,col=5::${FILE_LIST}"
 
 EVENT_DATA=$(cat $GITHUB_EVENT_PATH)
 echo $EVENT_DATA | jq .
@@ -12,13 +19,15 @@ RELEASE_NAME=$(echo $EVENT_DATA | jq -r .release.tag_name)
 PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
 NAME="${PROJECT_NAME}_${RELEASE_NAME}_${GOOS}_${GOARCH}"
 
-EXT=''
-
-if [ $GOOS == 'windows' ]; then
-  EXT='.exe'
+if [ -z "${EXTRA_FILES+x}" ]; then
+echo "::warning file=entrypoint.sh,line=22,col=1::EXTRA_FILES not set"
 fi
 
-tar cvfz tmp.tgz "${PROJECT_NAME}${EXT}"
+FILE_LIST="${FILE_LIST} ${EXTRA_FILES}"
+
+FILE_LIST=`echo "${FILE_LIST}" | awk '{$1=$1};1'`
+
+tar cvfz tmp.tgz ${FILE_LIST}
 CHECKSUM=$(md5sum tmp.tgz | cut -d ' ' -f 1)
 
 curl \


### PR DESCRIPTION
This PR provides significant upgrades and addresses 1 outstanding issue and Golang upgrade PR.

1. Docker golang version -> [1.14.1](https://github.com/ngs/go-release.action/pull/8)
1. Adding 2 more env vars: [CMD_PATH](https://github.com/ngs/go-release.action/issues/3) for buidling and EXTRA_FILES for packaging.
1. Allows a build.sh from a target built project to pass a custom file list.
1. A few extra warnings added to the job output.
1. Zip files for Windows releases.