### PR TITLE
build.sh: Add support for build flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.15-alpine
 MAINTAINER Atsushi Nagase <a@ngs.io> (https://ngs.io)
 
 LABEL "com.github.actions.name"="Go Release Binary"

--- a/build.sh
+++ b/build.sh
@@ -23,4 +23,8 @@ else
   fi
 fi
 
+if [ ! -e $OUTPUT ]; then
+  echo "::warning file=build.sh,line=27,col=1::OUTPUT is not set properly"
+fi
+
 echo ${OUTPUT}

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -eux
+#!/bin/sh -eux
 
 PROJECT_ROOT="/go/src/github.com/${GITHUB_REPOSITORY}"
 

--- a/build.sh
+++ b/build.sh
@@ -10,17 +10,17 @@ ln -s $GITHUB_WORKSPACE $PROJECT_ROOT
 cd $PROJECT_ROOT
 go get -v ./...
 
-EXT=''
-
-if [ $GOOS == 'windows' ]; then
-EXT='.exe'
-fi
-
 if [ -x "./build.sh" ]; then
   OUTPUT=`./build.sh "${CMD_PATH}"`
 else
   go build ${BUILD_FLAGS} "${CMD_PATH}"
-  OUTPUT="${PROJECT_NAME}${EXT}"
+  OUTPUT="${BIN_NAME:=$PROJECT_NAME}"
+
+  if [ $GOOS == 'windows' ]; then
+    EXT="$OUTPUT.exe"
+    mv $OUTPUT $EXT
+    OUTPUT=$EXT
+  fi
 fi
 
 echo ${OUTPUT}

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ fi
 if [ -x "./build.sh" ]; then
   OUTPUT=`./build.sh "${CMD_PATH}"`
 else
-  go build "${CMD_PATH}"
+  go build ${BUILD_FLAGS} "${CMD_PATH}"
   OUTPUT="${PROJECT_NAME}${EXT}"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ export PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
 NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${GOOS}_${GOARCH}"
 
 if [ -z "${EXTRA_FILES+x}" ]; then
-echo "::warning file=entrypoint.sh,line=22,col=1::EXTRA_FILES not set"
+  echo "::warning file=entrypoint.sh,line=24,col=1::EXTRA_FILES not set"
 fi
 
 FILE_LIST="${FILE_LIST} ${EXTRA_FILES}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -eux
+#!/bin/sh -eux
 
 if [ -z "${BUILD_FLAGS+x}" ]; then
   echo "::warning file=entrypoint.sh,line=6,col=1::BUILD_FLAGS not set"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,6 @@ fi
 
 FILE_LIST=`/build.sh`
 
-#echo "::warning file=/build.sh,line=1,col=5::${FILE_LIST}"
-
 EVENT_DATA=$(cat $GITHUB_EVENT_PATH)
 echo $EVENT_DATA | jq .
 UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ echo $EVENT_DATA | jq .
 UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)
 UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
 RELEASE_NAME=$(echo $EVENT_DATA | jq -r .release.tag_name)
-PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
+export PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
 NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${GOOS}_${GOARCH}"
 
 if [ -z "${EXTRA_FILES+x}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+if [ -z "${BUILD_FLAGS+x}" ]; then
+  echo "::warning file=entrypoint.sh,line=6,col=1::BUILD_FLAGS not set"
+  export BUILD_FLAGS=""
+fi
+
 if [ -z "${CMD_PATH+x}" ]; then
   echo "::warning file=entrypoint.sh,line=6,col=1::CMD_PATH not set"
   export CMD_PATH=""


### PR DESCRIPTION
Currently, it is not possible to adjust the build process for personal
needs.

With this patch it will be possible to add compiler and linker flags as
well as adjust the name of the output if the CMD_PATH != PROJECT_NAME,
e.g. "cmd/foo/main.go".